### PR TITLE
Code cleanup and simplification

### DIFF
--- a/Photon Code/SunRiseLamp.cpp
+++ b/Photon Code/SunRiseLamp.cpp
@@ -60,7 +60,7 @@ void SunRiseLamp::set() {
     pixelStringPtr->setBrightness(brightness);
 }
 
-//Convert kelvien to RGB
+// Convert kelvin to RGB
 uint32_t SunRiseLamp::kelvinToRGB(int kelvin) {
     if(kelvin <= 2000)
         return 0;
@@ -78,7 +78,7 @@ uint32_t SunRiseLamp::kelvinToRGB(int kelvin) {
         blue = 255;
     }
 
-    return ((uint32_t)clamp(red) << 16) | ((uint32_t)clamp(green) <<  8) | clamp(blue);
+    return Adafruit_NeoPixel::Color(red, green, blue);
 }
 
 int SunRiseLamp::clamp(int n) {

--- a/Photon Code/SunRiseLamp.cpp
+++ b/Photon Code/SunRiseLamp.cpp
@@ -1,176 +1,88 @@
 #include <application.h>
-
 #include "SunRiseLamp.h"
 #include "neopixel/neopixel.h"
 
-
-void SunRiseLamp::begin(int totalTime, int pixelCount, int pixelPin, int pixelType)
-{
-    _pixelCount = pixelCount;
-    _pixelPin = pixelPin;
-    _pixelType = pixelType;
-    pixelStringPtr = new Adafruit_NeoPixel(_pixelCount, _pixelPin, _pixelType);
-    colorInterval = (totalTime * 1000) /1500;
+void SunRiseLamp::begin(int totalTime, int pixelCount, int pixelPin, int pixelType) {
+    pixelStringPtr = new Adafruit_NeoPixel(pixelCount, pixelPin, pixelType);
+    colorInterval = (totalTime * 1000) / 1500;
     lastUpdate = millis();
-    colorIndex = 0;
-    pixelStringPtr->begin();
-    pixelStringPtr->setBrightness(0);
-    r = 0;
-    g = 0;
-    b = 0;
     sunRiseTemp = 0;
     brightness = 0;
-    
-    
+    pixelStringPtr->begin();
+    pixelStringPtr->setBrightness(0);
     pixelStringPtr->show();
     delay(5000);
 }
 
-bool SunRiseLamp::update()
-{
-    bool updateLeds = false;
-    
-    int currentMillis = millis();
-    if (currentMillis - lastUpdate > colorInterval)
-    {
-        
-        
-        if (direction == 1 && sunRiseTemp != 3500){
-            
-            //make the the smooth transition from 0 to 2255
-            if( brightness != 255 ){
-                
-                pixelStringPtr->setBrightness(brightness);
-                brightness++;
-                
-            }
-            //set the color temp and call the convertion funtion
-            sunRiseTemp++;
-            kelvinToRGB(sunRiseTemp);
-            
-            updateLeds = true;
-        }
-        else if (direction == -1 && sunRiseTemp != 2000)
-        {
-            //make the the smooth transition from 2000k to 0
-            if(sunRiseTemp <= 2255 && brightness !=0){
-                pixelStringPtr->setBrightness(brightness);
-                brightness--;
-            }
-            sunRiseTemp--;
-            kelvinToRGB(sunRiseTemp);
-            
-            if(sunRiseTemp <= 2000){
-                
-                r = 0;
-                g = 0;
-                b = 0;
-            }
-            
-            updateLeds = true;
-        }
-        else
-        {
-            lastUpdate = currentMillis;
+bool SunRiseLamp::update() {
+    unsigned long currentMillis = millis();
+    uint32_t color;
+    if (currentMillis - lastUpdate > colorInterval) {
+        if (direction == 1 && sunRiseTemp < 3500) {
+            //make a smooth transition from 0 to 2255
+            if( brightness < 255 )
+                pixelStringPtr->setBrightness(brightness++);
+        } else if (direction == -1 && sunRiseTemp > 2000) {
+            //make a smooth transition from 2000k to 0
+            if(sunRiseTemp <= 2255 && brightness > 0)
+                pixelStringPtr->setBrightness(brightness--);
+        } else {
             return direction = 0;
         }
         lastUpdate = currentMillis;
-    }
-    if(updateLeds)
-    {
-        
-        
-        for (int i = 0; i < _pixelCount; i++)
-        {
-            //we decleard r g and b in .h file
-            pixelStringPtr->setPixelColor(i, r, g, b);
-            
+        sunRiseTemp += direction;
+        color = kelvinToRGB(sunRiseTemp);
+        //Set color
+        for (uint16_t i = 0; i < pixelStringPtr->numPixels(); i++) {
+            pixelStringPtr->setPixelColor(i, color);
         }
         pixelStringPtr->show();
-        
-        
+        return true;
+    } else {
+        return false;
     }
-    return true;
 }
 
-void SunRiseLamp::rise()
-{
-    //set the starting tep and diraction of the sun
+// Set the starting temp and direction of the sun
+void SunRiseLamp::rise() {
     sunRiseTemp = 2000;
     direction = 1;
+    brightness = 0;
+    pixelStringPtr->setBrightness(brightness);
 }
 
-void SunRiseLamp::set()
-{
-    //set the starting bightnees and diraction of the sun
-    brightness = 255;
-    pixelStringPtr->setBrightness(255);
+
+// Set the starting temp and direction of the sun
+void SunRiseLamp::set() {
     sunRiseTemp = 3500;
     direction = -1;
+    brightness = 255;
+    pixelStringPtr->setBrightness(brightness);
 }
-
-
 
 //Convert kelvien to RGB
-
-void SunRiseLamp::kelvinToRGB(int kelvin){
-    
+uint32_t SunRiseLamp::kelvinToRGB(int kelvin) {
+    if(kelvin <= 2000)
+        return 0;
     int temp = kelvin / 100;
-    
-    int red, green, blue;
-    
-    if( temp <= 66 ){
-        
-        red = 255;
-        
-        green = temp;
-        green = 99.4708025861 * log(green) - 161.1195681661;
-        
-        
-        if( temp <= 19){
-            
-            blue = 0;
-            
-        } else {
-            
-            blue = temp-10;
-            blue = 138.5177312231 * log(blue) - 305.0447927307;
-            
+    int red = 255, green, blue = 0;
+
+    if( temp <= 66 ) {
+        green = 99.4708025861 * log(temp) - 161.1195681661;
+        if( temp > 19) {
+            blue = 138.5177312231 * log(temp - 10) - 305.0447927307;
         }
-        
     } else {
-        
-        red = temp - 60;
-        red = 329.698727446 * pow(red, -0.1332047592);
-        
-        green = temp - 60;
-        green = 288.1221695283 * pow(green, -0.0755148492 );
-        
+        red = 329.698727446 * pow(temp - 60, -0.1332047592);
+        green = 288.1221695283 * pow(temp - 60, -0.0755148492);
         blue = 255;
-        
     }
-    
-    
-    
-    r = clamp(red,   0, 255);
-    g = clamp(green, 0, 255);
-    b = clamp(blue,  0, 255);
-    
-    
-    
+
+    return ((uint32_t)clamp(red) << 16) | ((uint32_t)clamp(green) <<  8) | clamp(blue);
 }
 
-int SunRiseLamp::clamp(int x,int min,int max ){
-    
-    if(x<min){ return min; }
-    if(x>max){ return max; }
-    
-    return x;
+int SunRiseLamp::clamp(int n) {
+    int x=n>255?255:n;
+    return x<0?0:x;
 }
-
-
-
-
-
-
 

--- a/Photon Code/SunRiseLamp.cpp
+++ b/Photon Code/SunRiseLamp.cpp
@@ -2,41 +2,37 @@
 #include "SunRiseLamp.h"
 #include "neopixel/neopixel.h"
 
-void SunRiseLamp::begin(int totalTime, int pixelCount, int pixelPin, int pixelType) {
-    pixelStringPtr = new Adafruit_NeoPixel(pixelCount, pixelPin, pixelType);
+SunRiseLamp::SunRiseLamp(int totalTime, int pixelCount, int pixelPin, int pixelType) {
     colorInterval = (totalTime * 1000) / 1500;
-    lastUpdate = millis();
     sunRiseTemp = 0;
     brightness = 0;
-    pixelStringPtr->begin();
-    pixelStringPtr->setBrightness(0);
-    pixelStringPtr->show();
-    delay(5000);
+    neoPixelPtr = new Adafruit_NeoPixel(pixelCount, pixelPin, pixelType);
+    neoPixelPtr->begin();
+    neoPixelPtr->setBrightness(0);
+    neoPixelPtr->show();
+}
+
+void SunRiseLamp::begin() {
+    lastUpdate = millis();
 }
 
 bool SunRiseLamp::update() {
     unsigned long currentMillis = millis();
-    uint32_t color;
     if (currentMillis - lastUpdate > colorInterval) {
         if (direction == 1 && sunRiseTemp < 3500) {
             //make a smooth transition from 0 to 2255
             if( brightness < 255 )
-                pixelStringPtr->setBrightness(brightness++);
+                neoPixelPtr->setBrightness(brightness++);
         } else if (direction == -1 && sunRiseTemp > 2000) {
             //make a smooth transition from 2000k to 0
             if(sunRiseTemp <= 2255 && brightness > 0)
-                pixelStringPtr->setBrightness(brightness--);
+                neoPixelPtr->setBrightness(brightness--);
         } else {
-            return direction = 0;
+            return (direction = 0);
         }
         lastUpdate = currentMillis;
         sunRiseTemp += direction;
-        color = kelvinToRGB(sunRiseTemp);
-        //Set color
-        for (uint16_t i = 0; i < pixelStringPtr->numPixels(); i++) {
-            pixelStringPtr->setPixelColor(i, color);
-        }
-        pixelStringPtr->show();
+        colorAll(kelvinToRGB(sunRiseTemp));
         return true;
     } else {
         return false;
@@ -48,7 +44,13 @@ void SunRiseLamp::rise() {
     sunRiseTemp = 2000;
     direction = 1;
     brightness = 0;
-    pixelStringPtr->setBrightness(brightness);
+    neoPixelPtr->setBrightness(brightness);
+}
+
+void SunRiseLamp::rise(int totalTime) {
+    if(totalTime >= 15)
+        colorInterval = (totalTime * 1000) / 1500;
+    rise();
 }
 
 
@@ -57,7 +59,7 @@ void SunRiseLamp::set() {
     sunRiseTemp = 3500;
     direction = -1;
     brightness = 255;
-    pixelStringPtr->setBrightness(brightness);
+    neoPixelPtr->setBrightness(brightness);
 }
 
 // Convert kelvin to RGB
@@ -84,5 +86,13 @@ uint32_t SunRiseLamp::kelvinToRGB(int kelvin) {
 int SunRiseLamp::clamp(int n) {
     int x=n>255?255:n;
     return x<0?0:x;
+}
+
+// Set all pixels in the strip to a solid color
+void SunRiseLamp::colorAll(uint32_t c) {
+  for(uint16_t i = 0; i < neoPixelPtr->numPixels(); i++) {
+    neoPixelPtr->setPixelColor(i, c);
+  }
+  neoPixelPtr->show();
 }
 

--- a/Photon Code/SunRiseLamp.h
+++ b/Photon Code/SunRiseLamp.h
@@ -7,17 +7,19 @@
 
 class SunRiseLamp {
 public:
-    SunRiseLamp() {};
-    void begin(int totalTime, int pixelCount, int pixelPin, int pixelType);	// total time for sunrise
+    SunRiseLamp(int totalTime, int pixelCount, int pixelPin, int pixelType);
+    void begin();
     bool update();
     void rise();
+    void rise(int totalTime); // total time for sunrise
     void set();
     uint32_t kelvinToRGB(int kelvin);
     int clamp(int x);
+    void colorAll(uint32_t c);
 
 private:
-    Adafruit_NeoPixel* pixelStringPtr = NULL;
-    int colorInterval;
+    Adafruit_NeoPixel* neoPixelPtr = NULL;
+    unsigned int  colorInterval;
     unsigned long lastUpdate;
     int direction = 0;
     int sunRiseTemp;

--- a/Photon Code/SunRiseLamp.h
+++ b/Photon Code/SunRiseLamp.h
@@ -5,9 +5,6 @@
 #include "neopixel/neopixel.h"
 #include "math.h"
 
-
-
-
 class SunRiseLamp {
 public:
     SunRiseLamp() {};
@@ -15,25 +12,17 @@ public:
     bool update();
     void rise();
     void set();
-    void kelvinToRGB(int kelvin);
-    int  clamp(int x,int min,int max);
-    
+    uint32_t kelvinToRGB(int kelvin);
+    int clamp(int x);
+
 private:
     Adafruit_NeoPixel* pixelStringPtr = NULL;
     int colorInterval;
-    int lastUpdate;
-    int colorIndex = 0;
+    unsigned long lastUpdate;
     int direction = 0;
-    int _pixelCount;
-    int _pixelPin;
-    int _pixelType;
     int sunRiseTemp;
-    int r;
-    int g;
-    int b;
     int brightness;
-    
-    
 };
 
 #endif
+


### PR DESCRIPTION
I'm the kind of guy that likes shorter code, as it is generally easier to read. Have modified the code to make it clearer what it does.

The `kelvinToRGB(int)` have been changed so it returns an `uint32_t` that can be used directly by the NeoPixel code [`setPixelColor(uint16_t n, uint32_t c)`][1], getting rid of the `r, g, b` integers.


[1]: https://github.com/technobly/SparkCore-NeoPixel/blob/master/firmware/neopixel.h#L81